### PR TITLE
Custom Attributes for #[kernel]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ use accel_derive::kernel;
 use accel::*;
 
 #[kernel]
+#[depends("accel-core" = "0.1")]
 pub unsafe fn add(a: *const f64, b: *const f64, c: *mut f64, n: usize) {
     let i = accel_core::index();
     if (i as usize) < n {

--- a/accel-core/README.md
+++ b/accel-core/README.md
@@ -5,6 +5,3 @@ accel-core
 [![docs.rs](https://docs.rs/accel-core/badge.svg)](https://docs.rs/accel-core)
 
 Support crate for writing kernels
-
-- This crate will automatically be inserted by [ptx_builder](../src/ptx_builder) into the kernel crate.
-- If `$ACCEL_HOME` environmental value exists, `$ACCEL_HOME/accel-core` is used. This is useful for debug.

--- a/accel-derive/src/lib.rs
+++ b/accel-derive/src/lib.rs
@@ -81,12 +81,15 @@ fn parse_depends(func: &Function) -> Depends {
     for attr in &func.attrs {
         let path = &attr.path;
         let path = &quote!{#path}.to_string();
-        if path != "depends" {
-            unreachable!("Unsupported attribute: {:?}", path);
-        }
         let tts = &attr.tts[0];
         let tts = &quote!{#tts}.to_string();
-        deps.parse_append(tts);
+        let pene: &[_] = &['(', ')'];
+        let dep = tts.trim_matches(pene);
+        match path as &str {
+            "depends" => deps.push(Crate::from_depends_str(dep)),
+            "depends_path" => deps.push(Crate::from_depends_path_str(dep)),
+            _ => unreachable!("Unsupported attribute: {:?}", path),
+        }
     }
     deps
 }

--- a/accel-derive/src/lib.rs
+++ b/accel-derive/src/lib.rs
@@ -104,15 +104,18 @@ fn func2kernel(func: &Function) -> String {
     let output = &func.output;
     let block = &func.block;
 
+    let deps = parse_depends(func);
+    let crates: Vec<Ident> = deps.iter()
+        .map(|c| c.name().replace("-", "_").into())
+        .collect();
     let kernel =
         quote!{
         #![feature(abi_ptx)]
         #![no_std]
-        extern crate accel_core;
+        #(extern crate #crates;), *
         #[no_mangle]
         #vis #unsafety extern "ptx-kernel" #fn_token #ident(#inputs) #output #block
     };
-    let deps = parse_depends(func);
     compile(&kernel.to_string(), deps)
 }
 

--- a/accel-example/src/main.rs
+++ b/accel-example/src/main.rs
@@ -7,6 +7,7 @@ use accel_derive::kernel;
 use accel::*;
 
 #[kernel]
+#[depends("accel-core" = "0.1.0")]
 pub unsafe fn add(a: *const f64, b: *const f64, c: *mut f64, n: usize) {
     let i = accel_core::index();
     if (i as usize) < n {

--- a/src/ptx_builder/config.rs
+++ b/src/ptx_builder/config.rs
@@ -40,6 +40,10 @@ pub struct Crate {
 }
 
 impl Crate {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     pub fn from_depends_str(dep: &str) -> Self {
         let pat: &[_] = &[' ', '"'];
         let tokens: Vec<_> = dep.split('=').map(|s| s.trim_matches(pat)).collect();

--- a/src/ptx_builder/config.rs
+++ b/src/ptx_builder/config.rs
@@ -7,6 +7,10 @@ use toml;
 pub struct Depends(Vec<Crate>);
 
 impl Depends {
+    pub fn new() -> Self {
+        Depends(Vec::new())
+    }
+
     pub fn parse_append(&mut self, deps: &str) {
         self.push(Crate::parse(deps))
     }


### PR DESCRIPTION
Add support of two custom attributes:

```rust
#[kernel]
#[depends("accel-core" = "0.1.0")]
fn add(...) { ... }
```

```rust
#[kernel]
#[depends_path("accel-core" = "/some/path")]
fn add(...) { ... }
```

The version specification can be skipped for `depends` attribute:

```rust
#[kernel]
#[depends("accel-core")]  // corresponds to accel-core = "*"
fn add(...) { ... }
```

These generates corresponding entries in Cargo.toml and lib.rs.