### PR TITLE
Handle Windows path separators in build script.

### DIFF
--- a/cuda-sys/build.rs
+++ b/cuda-sys/build.rs
@@ -1,12 +1,25 @@
 use std::env;
 
-fn main() {
+fn find_library_paths() -> Vec<String> {
     match env::var("CUDA_LIBRARY_PATH") {
-        Ok(path) => for p in path.split(":") {
-            println!("cargo:rustc-link-search=native={}", p);
+        Ok(path) => {
+            let split_char = if cfg!(target_os="windows") {
+                ";"
+            }
+            else {
+                ":"
+            };
+
+            path.split(split_char).map(|s| s.to_owned()).collect::<Vec<_>>()
         },
-        Err(_) => {}
-    };
+        Err(_) => vec![]
+    }
+}
+
+fn main() {
+    for p in find_library_paths() {
+        println!("cargo:rustc-link-search=native={}", p);
+    }
     println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=cublas");


### PR DESCRIPTION
This fixes https://github.com/termoshtt/accel/issues/36 and enables use of `CUDA_LIBRARY_PATH` when building on Windows.