### PR TITLE
Improve Error Message When Kernel Compilation Fails

### DIFF
--- a/nvptx/src/compile.rs
+++ b/nvptx/src/compile.rs
@@ -99,7 +99,7 @@ impl Builder {
         self.generate_manifest()?;
         self.copy_triplet()?;
         self.save(kernel, "src/lib.rs").log(Step::Ready)?;
-        self.format()?;
+        self.format();
         self.clean();
         self.build()?;
         self.link()?;
@@ -173,12 +173,15 @@ impl Builder {
         };
     }
 
-    fn format(&self) -> Result<()> {
-        // TODO: This should not block the build, just warn.
-        process::Command::new("cargo")
+    fn format(&self) {
+        let result = process::Command::new("cargo")
             .args(&["fmt"])
             .current_dir(&self.path)
-            .check_run(Step::Format)
+            .check_run(Step::Format);
+
+        if let Err(e) = result {
+            eprintln!("Warning: {:?}", e);
+        }
     }
 }
 

--- a/nvptx/src/compile.rs
+++ b/nvptx/src/compile.rs
@@ -127,7 +127,7 @@ impl Builder {
         let pat_rsbc = format!("{}/target/**/deps/*.o", self.path.display());
         let bcs: Vec<_> = glob(&pat_rsbc)
             .unwrap()
-            .map(|x| x.unwrap().to_str().unwrap().to_owned())
+            .map(|x| fs::canonicalize(x.unwrap()).unwrap().to_str().unwrap().to_owned())
             .collect();
         process::Command::new("llvm-link")
             .args(&bcs)


### PR DESCRIPTION
The main effect of these changes is to provide the user with clearer error messages when the kernel compilation fails.

There are also some changes to make the kernel compilation more robust; the arguments to `llvm-link` are now converted to absolute paths (which makes it possible to put the auto-generated kernel crate at a relative path rather than an absolute one), and the build will no longer fail if `cargo fmt` fails (since it's not really critical to compilation, a warning is printed instead).