### PR TITLE
Support *-6.0 / *-7.0 naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,51 @@
 version: 2
-
 jobs:
-  build:
+  check_format:
     docker:
-      - image: termoshtt/rust-cuda
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
     steps:
       - checkout
-      - run:
-          name: Check format
-          command: |
-            cargo fmt --all -- --write-mode=diff
+      - run: cargo fmt --all -- --write-mode=diff
+
+  check_cuda_sys:
+    docker:
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
       - run:
           name: Check cuda-sys
           command: |
             cd cuda-sys
             cargo check
+
+  check_derive:
+    docker:
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
       - run:
           name: check accel-derive
           command: |
             cd accel-derive
             cargo check
+
+  check_nvptx:
+    docker:
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
       - run:
           name: test nvptx
           command: |
             cd nvptx
             cargo test -v
+
+  check_nvptx_60:
+    docker:
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1-llvm6.0
+      - run:
+          name: test nvptx
+          command: |
+            cd nvptx
+            cargo test -v
+
+  build_core:
+    docker:
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
       - run:
           name: build PTX of accel-core
           command: |
@@ -32,7 +53,22 @@ jobs:
             cargo install -f
             cd ../accel-core
             cargo nvptx
+
+  build_example_add:
+    docker:
+      - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
       - run:
           name: Check accel
           command: |
             cargo check -v --example add
+
+workflows:
+  version: 2
+  tests:
+    jobs:
+      - check_format
+      - check_derive
+      - check_nvptx
+      - check_nvptx_60
+      - build_core
+      - build_example_add

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
   check_cuda_sys:
     docker:
       - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
+    steps:
+      - checkout
       - run:
           name: Check cuda-sys
           command: |
@@ -19,6 +21,8 @@ jobs:
   check_derive:
     docker:
       - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
+    steps:
+      - checkout
       - run:
           name: check accel-derive
           command: |
@@ -28,6 +32,8 @@ jobs:
   check_nvptx:
     docker:
       - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
+    steps:
+      - checkout
       - run:
           name: test nvptx
           command: |
@@ -37,6 +43,8 @@ jobs:
   check_nvptx_60:
     docker:
       - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1-llvm6.0
+    steps:
+      - checkout
       - run:
           name: test nvptx
           command: |
@@ -46,6 +54,8 @@ jobs:
   build_core:
     docker:
       - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
+    steps:
+      - checkout
       - run:
           name: build PTX of accel-core
           command: |
@@ -57,6 +67,8 @@ jobs:
   build_example_add:
     docker:
       - image: registry.gitlab.com/termoshtt/rust-cuda:cuda9.1
+    steps:
+      - checkout
       - run:
           name: Check accel
           command: |

--- a/nvptx/src/compile.rs
+++ b/nvptx/src/compile.rs
@@ -225,12 +225,12 @@ fn test_using_help(name: &str) -> bool {
 fn llvm_command(name: &str) -> Result<String> {
     let name6 = format!("{}-6.0", name);
     let name7 = format!("{}-7.0", name);
-    if test_using_help(name) {
-        Ok(name.into())
-    } else if test_using_help(&name6) {
+    if test_using_help(&name6) {
         Ok(name6)
     } else if test_using_help(&name7) {
         Ok(name7)
+    } else if test_using_help(&name) {
+        Ok(name.into())
     } else {
         Err(CompileError::LLVMCommandNotFound(name.into()))
     }


### PR DESCRIPTION
Resolve #35 
Related to #32 

- Support `llc-6.0` and `llc-7.0` naming rule
  - Check if they exist by executing `llc-60 --help`