### PR TITLE
Make Dim3 and Idx3 fields public.

### DIFF
--- a/accel-core/src/lib.rs
+++ b/accel-core/src/lib.rs
@@ -2,15 +2,15 @@
 #![no_std]
 
 pub struct Dim3 {
-    x: i32,
-    y: i32,
-    z: i32,
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
 }
 
 pub struct Idx3 {
-    x: i32,
-    y: i32,
-    z: i32,
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
 }
 
 pub fn block_dim() -> Dim3 {


### PR DESCRIPTION
This makes it possible to use these structures and the `block_dim()`/`block_idx()`/etc. functions outside of the `accel-core` crate. Otherwise, the user must call the `nvptx_block_idx_x()` intrinsics directly.