### PR TITLE
Build core with nvptx target

### DIFF
--- a/accel-core/.cargo/config
+++ b/accel-core/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "nvptx64-nvidia-cuda"

--- a/accel-core/Cargo.toml
+++ b/accel-core/Cargo.toml
@@ -10,3 +10,6 @@ keywords      = ["GPGPU", "CUDA", "platform-intrinsic"]
 license       = "MIT"
 readme        = "README.md"
 categories    = []
+
+[lib]
+crate-type = ["cdylib"]

--- a/accel-core/src/indexing.rs
+++ b/accel-core/src/indexing.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+pub fn index() -> isize {
+    let block_id = block_idx().into_id(grid_dim());
+    let thread_id = thread_idx().into_id(block_dim());
+    (block_id + thread_id) as isize
+}

--- a/accel-core/src/intrinsics.rs
+++ b/accel-core/src/intrinsics.rs
@@ -1,0 +1,16 @@
+extern "platform-intrinsic" {
+    pub fn nvptx_block_dim_x() -> i32;
+    pub fn nvptx_block_dim_y() -> i32;
+    pub fn nvptx_block_dim_z() -> i32;
+    pub fn nvptx_block_idx_x() -> i32;
+    pub fn nvptx_block_idx_y() -> i32;
+    pub fn nvptx_block_idx_z() -> i32;
+    pub fn nvptx_grid_dim_x() -> i32;
+    pub fn nvptx_grid_dim_y() -> i32;
+    pub fn nvptx_grid_dim_z() -> i32;
+    pub fn nvptx_syncthreads() -> ();
+    pub fn nvptx_thread_idx_x() -> i32;
+    pub fn nvptx_thread_idx_y() -> i32;
+    pub fn nvptx_thread_idx_z() -> i32;
+}
+

--- a/accel-core/src/lib.rs
+++ b/accel-core/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(platform_intrinsics)]
 
+mod intrinsics;
+pub use intrinsics::*;
 
 pub struct Dim3 {
     pub x: i32,
@@ -63,22 +65,6 @@ impl Idx3 {
     pub fn into_id(&self, dim: Dim3) -> i32 {
         self.x + self.y * dim.x + self.z * dim.x * dim.y
     }
-}
-
-extern "platform-intrinsic" {
-    pub fn nvptx_block_dim_x() -> i32;
-    pub fn nvptx_block_dim_y() -> i32;
-    pub fn nvptx_block_dim_z() -> i32;
-    pub fn nvptx_block_idx_x() -> i32;
-    pub fn nvptx_block_idx_y() -> i32;
-    pub fn nvptx_block_idx_z() -> i32;
-    pub fn nvptx_grid_dim_x() -> i32;
-    pub fn nvptx_grid_dim_y() -> i32;
-    pub fn nvptx_grid_dim_z() -> i32;
-    pub fn nvptx_syncthreads() -> ();
-    pub fn nvptx_thread_idx_x() -> i32;
-    pub fn nvptx_thread_idx_y() -> i32;
-    pub fn nvptx_thread_idx_z() -> i32;
 }
 
 pub fn index() -> isize {

--- a/accel-core/src/lib.rs
+++ b/accel-core/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(platform_intrinsics)]
-#![no_std]
+
 
 pub struct Dim3 {
     pub x: i32,

--- a/accel-core/src/lib.rs
+++ b/accel-core/src/lib.rs
@@ -1,7 +1,10 @@
 #![feature(platform_intrinsics)]
 
 mod intrinsics;
+mod indexing;
+
 pub use intrinsics::*;
+pub use indexing::*;
 
 pub struct Dim3 {
     pub x: i32,
@@ -65,10 +68,4 @@ impl Idx3 {
     pub fn into_id(&self, dim: Dim3) -> i32 {
         self.x + self.y * dim.x + self.z * dim.x * dim.y
     }
-}
-
-pub fn index() -> isize {
-    let block_id = block_idx().into_id(grid_dim());
-    let thread_id = thread_idx().into_id(block_dim());
-    (block_id + thread_id) as isize
 }


### PR DESCRIPTION
Experiment to use nvptx-enabled rustc  at https://github.com/rust-accel/rust

Features
-----------
- Use libstd (based on wasm implementations)
- Linking LLVM bitcodes by `llvm-link` *in rustc*
- Compile into a linked LLVM bitcode

Links
-------
- Enable nvptx target https://github.com/rust-accel/rust/pull/1
- llvm-link in rustc https://github.com/rust-accel/rust/pull/3

See also #31 